### PR TITLE
Not defined empty

### DIFF
--- a/lib/mediator/parser.rb
+++ b/lib/mediator/parser.rb
@@ -15,8 +15,9 @@ class Mediator
       (options && options[:value]) || data[selector] || data[selector.to_s]
     end
 
-    def has? name
-      !!get(name)
+    def has? name, options = nil
+      selector = (options && options[:from]) || name
+      (options && options.has_key?(:value)) || data.has_key?(selector) || data.has_key?(selector.to_s)
     end
 
     def id name, options = {}
@@ -39,6 +40,8 @@ class Mediator
       if name[-1] == "?"
         name = name[0..-2].intern
       end
+
+      return unless has? name, options
 
       value = get name, options
       return if empty? value, options

--- a/lib/mediator/processor.rb
+++ b/lib/mediator/processor.rb
@@ -2,7 +2,7 @@ class Mediator
   class Processor
     def empty? value, options = nil
       !(options && options[:empty]) &&
-        (value.nil? || value.respond_to?(:empty?) && value.empty?)
+        (value.nil? || (value.respond_to?(:empty?) && value.empty?))
     end
   end
 end

--- a/test/mediator_parser_test.rb
+++ b/test/mediator_parser_test.rb
@@ -54,9 +54,11 @@ describe Mediator::Parser do
 
   describe "key" do
     before do
-      @parser = Mediator::Parser.new @mediator,
+      @data = {
         emptystring: "", emptyarray: [], isnil: nil,
-        somevalue: :gni, predicate: true
+        somevalue: :gni, predicate: true, othernil: nil
+      }
+      @parser = Mediator::Parser.new @mediator, @data
     end
 
     it "parses some values" do
@@ -65,11 +67,20 @@ describe Mediator::Parser do
       assert_equal :gni, @subject.somevalue
     end
 
-    it "sets unconditionally with empty: true" do
+    it "sets unconditionally with empty: true and data holds an empty value for that key." do
+      @subject.othernil = :not_nil
+
+      assert @data.has_key?(:othernil)
+      @parser.key :othernil, empty: true
+      assert_nil @subject.othernil
+    end
+
+    it "does not touch a key with empty: true when data does not have that key defined." do
       @subject.foo = :foo
 
+      refute @data.has_key?(:foo)
       @parser.key :foo, empty: true
-      assert_nil @subject.foo
+      assert_equal :foo, @subject.foo
     end
 
     it "removes trailing '?' from predicates" do


### PR DESCRIPTION
Avoid setting attribute to `nil` on parsed object when using option `empty: true` but subject does not define that key.
