### PR TITLE
Registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+.idea

--- a/lib/mediator/parser.rb
+++ b/lib/mediator/parser.rb
@@ -76,7 +76,7 @@ class Mediator
     def sub subj, data, options, &block
       return if empty? data, options or subj.nil?
 
-      Mediator[subj, mediator].parse data
+      Mediator[subj, context: mediator].parse data
       block[subj] if block
 
       subj

--- a/lib/mediator/registry.rb
+++ b/lib/mediator/registry.rb
@@ -25,25 +25,45 @@ class Mediator
     #     Mediator.for B.new  #  => A
     #
     # Mediators are searched in reverse insertion order.
+    #
+    # Options:
+    #   context  - passed to new context
+    #   registry - optional registry map to use instead of default
 
-    def for subject, context = nil
-      map.keys.reverse.each do |criteria|
-        return map[criteria].new subject, context if criteria === subject
+    def for subject, opts = {}
+      context = opts[:context]
+
+      reg = opts[:registry] ||
+          (context.respond_to?(:registered_with) && context.registered_with)
+      
+      registry(reg).keys.reverse.each do |criteria|
+        return registry[criteria].new subject, context if criteria === subject
       end
 
       raise Error, "Can't find a Mediator for #{subject.inspect}."
     end
 
-    # Sugar for `for`.
+    # Returns a mediator registry. If no arg is passed the default registry
+    # is returned. 
 
-    def [] subject, context = nil
-      self.for subject, context
+    def registry reg = nil
+      reg ||= :default
+      reg.is_a?(Symbol) ? registries[reg] : reg
     end
 
-    # A map from subject class or block to Mediator subclass.
+    # Sugar for `for`.
 
-    def map
-      @@map ||= {}
+    def [] subject, opts = {}
+      self.for subject, opts
+    end
+
+    def registries
+      @@registries ||= Hash.new { |h,k| h[k] = {} }
+    end
+
+    def registered_with registry = nil
+      return @with if registry.nil?
+      @with = registry
     end
 
     # Sugar for creating and registering a Mediator subclass.
@@ -58,17 +78,25 @@ class Mediator
     # `subject` can take a block instead. When the mediator for a
     # subject is discovered with `Mediator.for` the given block will be
     # passed the subject and can return `true` or `false`.
+    # Can take an optional hash specifying what to register the mediator with.
 
     def register mklass, *subjects, &block
+      opts = subjects.last.is_a?(Hash) ? subjects.pop : {}
+      reg_map = registry opts[:registry]
+
       if block_given?
         unless subjects.empty?
           raise ArgumentError, "Can't provide both a subject and a block."
         end
 
-        map[block] = mklass
+        reg_map[block] = mklass
+        mklass.registered_with(reg_map) if mklass.respond_to? :registered_with
       end
 
-      subjects.each { |k| map[k] = mklass }
+      subjects.each do |k|
+        reg_map[k] = mklass
+        mklass.registered_with(reg_map) if mklass.respond_to? :registered_with
+      end
 
       mklass
     end

--- a/lib/mediator/renderer.rb
+++ b/lib/mediator/renderer.rb
@@ -74,7 +74,7 @@ class Mediator
     private
 
     def sub value, options, &block
-      rendered = Mediator[value, mediator].render
+      rendered = Mediator[value, context: mediator].render
       block ? block[rendered] : rendered
     end
 

--- a/test/mediator_parser_test.rb
+++ b/test/mediator_parser_test.rb
@@ -5,7 +5,7 @@ require "ostruct"
 
 describe Mediator::Parser do
   before do
-    Mediator.map.clear
+    Mediator.registries.clear
 
     @subject  = OpenStruct.new
     @mediator = Mediator.new @subject

--- a/test/mediator_renderer_test.rb
+++ b/test/mediator_renderer_test.rb
@@ -5,7 +5,7 @@ require "ostruct"
 
 describe Mediator::Renderer do
   before do
-    Mediator.map.clear
+    Mediator.registries.clear
   end
 
   it "has data" do

--- a/test/mediator_test.rb
+++ b/test/mediator_test.rb
@@ -4,7 +4,7 @@ require "ostruct"
 
 describe Mediator do
   before do
-    Mediator.map.clear
+    Mediator.registries.clear
   end
 
   describe "initialization" do
@@ -266,22 +266,22 @@ describe Mediator do
       c = Class.new Mediator
       Mediator.register c, Symbol
 
-      assert_equal c, Mediator.map[Symbol]
+      assert_equal c, Mediator.registry[Symbol]
     end
 
     it "can register multiple classes" do
       c = Class.new Mediator
       Mediator.register c, String, Symbol
 
-      assert_equal c, Mediator.map[String]
-      assert_equal c, Mediator.map[Symbol]
+      assert_equal c, Mediator.registry[String]
+      assert_equal c, Mediator.registry[Symbol]
     end
 
     it "can register with a block" do
       c = Class.new Mediator
       Mediator.register(c) { |s| Symbol === s }
 
-      b = Mediator.map.keys.first
+      b = Mediator.registry.keys.first
       refute_nil b
 
       assert b[:foo]
@@ -298,9 +298,18 @@ describe Mediator do
       assert_equal "Can't provide both a subject and a block.", ex.message
     end
 
+    it "allows for alternate registry" do
+      c = Class.new Mediator
+      r = {}
+      assert_equal c, Mediator.register(c, String, registry: r)
+      assert_equal c, r[String]
+      assert_equal r, c.registered_with
+    end
+
     it "returns the registered thing" do
       c = Class.new Mediator
       assert_equal c, Mediator.register(c, String)
     end
+
   end
 end

--- a/test/mediator_test.rb
+++ b/test/mediator_test.rb
@@ -300,10 +300,14 @@ describe Mediator do
 
     it "allows for alternate registry" do
       c = Class.new Mediator
-      r = {}
-      assert_equal c, Mediator.register(c, String, registry: r)
+      assert_equal c, Mediator.register(c, String, registry: :monkeys )
+
+      r = c.registries[:monkeys]
+      refute_nil r
+
       assert_equal c, r[String]
-      assert_equal r, c.registered_with
+      assert_equal r, c.registry(c)
+      assert_equal r, c.registries[c]
     end
 
     it "returns the registered thing" do


### PR DESCRIPTION
Allow mediators to optionally register themselves like this:

```
  mediate Purchase, registry: :accounting do
    def render! r
      super
      ...
    end
```

And then be used like this:

```
    m = Mediator[p, registry: :accounting]
```

Note: passing a context to the mediator lookup helper has been changed. You must provide an options hash for args following the mediator subject (user in the case below):

```
Mediator[user, context: context]
```
